### PR TITLE
Update Yarn Install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.5.5
+------
+* Updated Yarn install process to use `--ignore-dependencies` rather than `--without-node``
+
+
 v0.5.4 [February 3, 2019](https://github.com/lando/hyperdrive/releases/tag/v0.5.4)
 -------------------------
 

--- a/installers/darwin.sh
+++ b/installers/darwin.sh
@@ -54,7 +54,7 @@ HOMEBREW_PREFIX="/usr/local"
 
   # Install yarn if needed
   if [[ $YARN_INSTALLED == "false" ]]; then
-    brew install yarn --without-node
+    brew install yarn --ignore-dependencies
   fi
 
   # Install lando if needed


### PR DESCRIPTION
`--without-node` flag has been replaced by `--ignore-dependencies`.  Swapped so a clean install can be completed.

Thank you so much for contributing code to hyperdrive!

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/hyperdrive/tree/master/CHANGELOG.md)
- [x] My code includes documentation updates if applicable.
- [x] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can improve our process.
